### PR TITLE
Store ref<EvalState> in CachedEvalError

### DIFF
--- a/src/libexpr/eval-cache.hh
+++ b/src/libexpr/eval-cache.hh
@@ -15,10 +15,11 @@ class AttrCursor;
 
 struct CachedEvalError : EvalError
 {
+    const ref<EvalState> state;
     const ref<AttrCursor> cursor;
     const Symbol attr;
 
-    CachedEvalError(ref<AttrCursor> cursor, Symbol attr);
+    CachedEvalError(ref<EvalState>, ref<AttrCursor> cursor, Symbol attr);
 
     /**
      * Evaluate this attribute, which should result in a regular


### PR DESCRIPTION
# Motivation

This makes the previous commits build.


# Context

- Newer versions store it in all EvalErrors.

- Merges into https://github.com/NixOS/nix/pull/11445

<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->
